### PR TITLE
New Field: Luxus Flag

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1936,7 +1936,7 @@ components:
             luxusFlag:
               type: string
               enum: [0, 0.5, 1.0]
-              description: 'Used for object value calculation (e.g. IAZI) and indicates whether an object is luxury or not: 0 = No, 0.5 = Partially, 1 = Yes.'
+              description: 'Used for object value calculation (e.g. IAZI) and indicates whether an object is luxury or not: 0 = No, 0.5 = Partially, 1 = Yes. Proposed Mapping of WuP-Values: 1.0-4.0 => 0 (No) / 4.1-4.5 => 0.5 (Partially) / 4.6-5.0 = >1.0 (Yes).'
               example: '0'
             constructionQualityType:
               $ref: '#/components/schemas/PropertyObjectRatingType'

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1933,6 +1933,11 @@ components:
               enum: [none, minergie, minergie-p, minergie-eco, minergie-p-eco]
               description: 'The minergie standard'
               example: 'minergie-p'
+            luxusFlag:
+              type: string
+              enum: [0, 0.5, 1.0]
+              description: 'If the property is luxury'
+              example: '0'
             constructionQualityType:
               $ref: '#/components/schemas/PropertyObjectRatingType'
             stateBuildingType:

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1936,7 +1936,7 @@ components:
             luxusFlag:
               type: string
               enum: [0, 0.5, 1.0]
-              description: 'If the property is luxury'
+              description: 'Used for object value calculation (e.g. IAZI) and indicates whether an object is luxury or not: 0 = No, 0.5 = Partially, 1 = Yes.'
               example: '0'
             constructionQualityType:
               $ref: '#/components/schemas/PropertyObjectRatingType'


### PR DESCRIPTION
For IAZI-estimations, the luxus flag is in "propertyObject" needed. Name: luxusFlag
Description: If the property is luxury
not required field
String, enum: [0, 0.5, 1.0]
0 = Nein
0.5 = Teilweise
1.0 = Ja

-> Zeile 1936-1940