### PR TITLE
New Setup: Property Renovation

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1950,7 +1950,10 @@ components:
                       - supporting_structure
                       - building_envelope_windows
                       - building_envelope_facade_balcony
-                    description: 'Type of Property Component which has been renovated'
+                      - interior_fittings
+                      - building_envelope
+                      - building_services
+                    description: 'Type of Property Component which has been renovated. Please use consistently either the detailed Component Types (e.g. interior_fittings_floor_cover) or the simple Component Types (e.g. interior_fittings)'
                     example: 'interior_fittings_floor_cover'
                   yearOfRenovation:
                     type: integer

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1928,6 +1928,37 @@ components:
               description: 'renovation year'
               example: 1990
               default: 0
+            propertyRenovations:
+              type: array
+              items:
+                type: object
+                properties:
+                  refurbishmentComponentType:
+                    type: string
+                    enum:
+                      - total
+                      - interior_fittings_kitchen
+                      - interior_fittings_bathroom_sanitary
+                      - interior_fittings_floor_cover
+                      - interior_fittings_remaining
+                      - building_envelope_pitched_roof
+                      - building_envelope_flat_roof
+                      - building_services_heat_production
+                      - building_services_heat_emission
+                      - buildings_services_electrical_ventilation_elevator
+                      - work_on_surroundings
+                      - supporting_structure
+                      - building_envelope_windows
+                      - building_envelope_facade_balcony
+                    description: 'Type of Property Component which has been renovated'
+                    example: 'interior_fittings_floor_cover'
+                  yearOfRenovation:
+                    type: integer
+                    description: 'renovation year'
+                    example: '2015'
+                    default: 0
+                  renovationCost:
+                    $ref: '#/components/schemas/Amount'
             minergieStandardType:
               type: string
               enum: [none, minergie, minergie-p, minergie-eco, minergie-p-eco]

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1959,6 +1959,7 @@ components:
                     default: 0
                   renovationCost:
                     $ref: '#/components/schemas/Amount'
+                    description: 'cost of renovation'
             minergieStandardType:
               type: string
               enum: [none, minergie, minergie-p, minergie-eco, minergie-p-eco]


### PR DESCRIPTION
Wüest Dimensions differentiates not just renovation: true/false. Wüest Dimensions has different refurbishment Component Types: total, interior_fittings_kitchen, interior_fittings_bathroom_sanitary, interior_fittings_floor_cover, interior_fittings_remaining building_envelope_pitched_roof, building_envelope_flat_roof, building_services_heat_production, building_services_heat_emission, buildings_services_electrical_ventilation_elevator, work_on_surroundings, supporting_structure, building_envelope_windows, building_envelope_facade_balcony

renovation should therefore be built as an own object with a list/array:

refurbishmentComponentType (string, enum: see above)
yearOfRenovation (similar to "renovationYear, but different name due to no duplicated fields)
renovationCost (see your Standard for "amount")