### PR TITLE
New Enum in Minergie Standard Type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1930,7 +1930,7 @@ components:
               default: 0
             minergieStandardType:
               type: string
-              enum: [none, minergie, minergie-p, minergie-eco, minergie-p-eco]
+              enum: [none, minergie, minergie-p, minergie-eco, minergie-p-eco, minergie-a, minergie-a-eco]
               description: 'The minergie standard'
               example: 'minergie-p'
             constructionQualityType:


### PR DESCRIPTION
Besides the current enum (none, minergie, minergie-p, minergie-eco, minergie-p-eco) IAZI now works with two additional minergieStandardTypes:

minergie-a
minergie-a-eco
We should accept this two new types in our enum in the field "minergieStandardType".

-> Teil von Zeile 1933