### PR TITLE
New Field: Property Type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1942,6 +1942,11 @@ components:
           enum: [main_residence, main_residence_with_use_restriction, second_residence, second_residence_with_use_restriction, rented_property, rented_property_with_use_restriction, other]
           description: 'The class of property (Main residence, second residence, rented).'
           example: 'main_residence'
+        propertyType:
+          type: string
+          enum: [single_family_house, condominium, vacation_house, vacation_condominium, agricultural_farm, 2or3_family_house, multi_family_house, residential_building_plot, building_plot_other, mixed_property, commercial_condominium, office_building, industrial_building, special_object]
+          description: 'The type of property'
+          example: 'single_familiy_house'
         ceilingHight:
           type: string
           enum: [especially_high, middle, especially_low]


### PR DESCRIPTION
We miss a field in "Property Objects":
field name: propertyType
description: The type of property
not required
string
enum: [single_family_house, condominium, vacation_house, vacation_condominium, agricultural_farm, 2or3_family_house, multi_family_house, residential_building_plot, building_plot_other, mixed_property, commercial_condominium, office_building, industrial_building, special_object]