### PR TITLE
New Field: Heat Emission

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1962,6 +1962,13 @@ components:
           enum: [premium, highlevel, basic, lowlevel]
           description: 'Building standard of the sanitary installations.'
           example: 'basic'
+        heatEmission:
+          type: array
+          items:
+            type: string
+            enum: [floor, radiator, stove, other]
+            description: 'Type of the heat emission'
+            example: 'floor'
         outsideConstructionZone:
           type: boolean
           description: 'If the property is outside of the construction zone.'


### PR DESCRIPTION
For the new Wüest Dimensions estimations, we miss a field in "Property Objects":

field name: heatEmission
description: Type of the heat emission
not required
array
string
enum: [floor, radiator, stove, other]

same line than #61