### PR TITLE
New Field: Number Of Rooms In Granny Flat

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1975,6 +1975,11 @@ components:
               format: double
               description: 'The number of the rooms.'
               example: 4.5
+            numberOfRoomsInGrannyFlat:
+              type:number
+              format: double
+              description: 'The number of the rooms in the granny flat'
+              example: '2.5'
             roomCountType:
               type: string
               enum: [kitchen_not_counted, kitchen_half_room, kitchen_full_room]

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1976,7 +1976,7 @@ components:
               description: 'The number of the rooms.'
               example: 4.5
             numberOfRoomsInGrannyFlat:
-              type:number
+              type: number
               format: double
               description: 'The number of the rooms in the granny flat'
               example: '2.5'


### PR DESCRIPTION
For Wüest Dimensions, we miss a field in "Property Objects":

field name: numberOfRoomsInGrannyFlat
description: The number of the rooms in the granny flat
not required
number, double