### PR TITLE
New Field: Environment Standard

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2093,6 +2093,11 @@ components:
               type: integer
               description: 'The surface area of the land.'
               example: 2000
+            environmentStandard:
+              type: string
+              enum: [high-level, basic, low-level]
+              description: 'The rating type'
+              example: 'basic'
             otherFeatures:
               type: array
               items:


### PR DESCRIPTION
For the property estimation service (Wüest Dimensions and IAZ), we miss a field in "Property Building Information" (for single family houses):

field name: environmentStandard
description: The rating type
not required
string
enum: [high-level, basic, low-level]