### PR TITLE
New Enum in Other Features in Property Building Information

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2097,7 +2097,7 @@ components:
               type: array
               items:
                 type: string
-                enum: [ventilation_system_without_mingergie, barrier-free_living, automated_building_control]
+                enum: [ventilation_system_without_mingergie, barrier-free_living, automated_building_control, indoor_pool, outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, passenger_elevator, freight_elevator]
                 description: 'Additional features and services.'
                 example: 'outdoor_pool'
             houseType:


### PR DESCRIPTION
In the Field "otherFeatures" in the Object "Property Building Information" for e.g. single family house some enum are missing for Wüest Dimensions. Could we please add the following enum: indoor_pool, outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, passenger_elevator, freight_elevator