### PR TITLE
New enum: Grammar mistake in Other Features

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2046,7 +2046,7 @@ components:
               type: array
               items:
                 type: string
-                enum: [coowned_garden_terrace_room, coowned_indoor_pool, coowned_outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, elevator_in_stairwell, elevator_into_apartment, ventilation_system_without_mingergie, barrier-free_living, automated_building_control]
+                enum: [coowned_garden_terrace_room, coowned_indoor_pool, coowned_outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, elevator_in_stairwell, elevator_into_apartment, ventilation_system_without_mingergie, barrier-free_living, automated_building_control, ventilation_system_without_minergie]
                 description: 'Additional features and services.'
                 example: 'coowned_outdoor_pool'
             quote:
@@ -2097,7 +2097,7 @@ components:
               type: array
               items:
                 type: string
-                enum: [ventilation_system_without_mingergie, barrier-free_living, automated_building_control]
+                enum: [ventilation_system_without_mingergie, barrier-free_living, automated_building_control, ventilation_system_without_minergie]
                 description: 'Additional features and services.'
                 example: 'outdoor_pool'
             houseType:


### PR DESCRIPTION
In the field "otherFeatures" in the object "propertyBuildingInformation" and in the object "propertyFlatInformation", there is a grammar mistake in the enum ventilation_system_without_mingergie.

Added new enum: ventilation_system_without_minergie