### PR TITLE
New Fields besides Object Price

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2132,6 +2132,19 @@ components:
               description: 'Payment received at the building right expiry.'
         objectPrice:
           $ref: '#/components/schemas/Amount'
+          description: 'Price paid to buy the property'
+        renovationAmount:
+          $ref: '#/components/schemas/Amount'
+          description: 'Amount needed to pay the planned renovation (Renovationsbetrag)'
+        investmentCost:
+          $ref: '#/components/schemas/Amount'
+          description: 'Total amount needed to pay object price and planned renovation (Total Anlagekosten)'
+        collateralValue:
+          $ref: '#/components/schemas/Amount'
+          description: 'Value of the property as base for the securization applying the lowest value principle (Belehnungsbasis)'
+        limitForLandEncumbrances:
+          $ref: '#/components/schemas/Amount'
+          description: 'The limit for land encumbrance according to Bundesgericht über das bäuerliche Bodenrecht, SR 211.412.11 (Belastungsgrenze BGBB)'
         estimation:
           type: object
           properties:


### PR DESCRIPTION
You know the field "objectPrice". In my view, this is the "Kaufpreis". Besides the "Kaufpreis" more types of amounts are relevant for an application. Can we add the following amounts after "object Price":

renovationAmount
description: Amount needed to pay the planned renovation (Renovationsbetrag) Type: see "Amount"
investmentCost
description: Total amount needed to pay object price and planned renovation (Total Anlagekosten) Type: see "Amount"
collateralValue
description: Value of the property as base for the securization applying the lowest value principle (Belehnungsbasis) Type: see "Amount"
limitForLandEncumbrances
description: The limit for land encumbrance according to Bundesgericht über das bäuerliche Bodenrecht, SR 211.412.11 (Belastungsgrenze BGBB)
Type: see "Amount"