### PR TITLE
Renaming Estimation Amount

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2143,6 +2143,7 @@ components:
                 - wup
             amount:
               $ref: '#/components/schemas/Amount'
+              description: 'Estimated Market value of the property'
             estimationDate:
               $ref: '#/components/schemas/Date'
         purchaseDate:


### PR DESCRIPTION
In the object "Estimation" you have the following fields:

estimationSourceType
amount
estimationDate
Estimation tools like WuP and IAZI know several "amounts". Therefore the field "Amount" is not meaningful. I suggest to rather call this field "marketValue".

Step 1 in next Release: description added.
Step 2 in Release V3.0: renaming of amount to "marketValue"