### PR TITLE
New Fields: Different Amounts in Estimation

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2143,6 +2143,15 @@ components:
                 - wup
             amount:
               $ref: '#/components/schemas/Amount'
+            statisticalPriceRangeMax:
+              $ref: '#/components/schemas/Amount'
+              description: 'Estimated statistical price range maximum'
+            statisticalPriceRangeMin:
+              $ref: '#/components/schemas/Amount'
+              description: 'Estimated statistical price range minimum'
+            yearlyRentalIncome:
+              $ref: '#/components/schemas/Amount'
+              description: 'Estimated rental income per year'
             estimationDate:
               $ref: '#/components/schemas/Date'
         purchaseDate:


### PR DESCRIPTION
In the object "Estimation" I would like to add more fields to this object:

statisticalPriceRangeMax
description: Estimated statistical price range maximum type: see Amount
statisticalPriceRangeMin
description: Estimated statistical price range minimum type: see Amount
yearlyRentalIncome
description: Estimated rental income per year
type: see Amount