### PR TITLE
New Field: Estimation ID

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2147,6 +2147,11 @@ components:
               $ref: '#/components/schemas/Date'
         purchaseDate:
           $ref: '#/components/schemas/Date'
+        estimationId
+          type: string
+          pattern: '^[a-zA-Z0-9]{6,10}$'
+          descpription: 'ID of the property estimation'
+          example: 'asd23f'
         remarks:
           type: string
     # ---------

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2149,7 +2149,7 @@ components:
           $ref: '#/components/schemas/Date'
         estimationId
           type: string
-          descpription: 'ID of the property estimation'
+          descpription: 'ID of the property estimation to connect the done estimation in the core banking system with the estimation of the tpp in the external estimation tool.'
           example: 'asd23f'
         remarks:
           type: string

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2149,7 +2149,6 @@ components:
           $ref: '#/components/schemas/Date'
         estimationId
           type: string
-          pattern: '^[a-zA-Z0-9]{6,10}$'
           descpription: 'ID of the property estimation'
           example: 'asd23f'
         remarks:


### PR DESCRIPTION
To connect the done estimation in the core banking system with the estimation of the tpp in the external estimation tool, it would be useful if we can transfer the estimationId as a unique key.

Therefore I would like to add the following field in the object "Estimation":
name: estimationId
description: ID of the property estimation
Type: string, pattern: '^[a-zA-Z0-9]{6,10}$'