### PR TITLE
New Field: Start Date

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2388,6 +2388,9 @@ components:
           type: string
         maturityDate:
           $ref: '#/components/schemas/Date'
+        startDate
+          $ref: '#/components/schemas/Date'
+          description: 'Start date of the mortgage'
         interest:
           $ref: '#/components/schemas/Interest'
         amountRange:


### PR DESCRIPTION
You have the field "MaturityDate". I miss the field "StartDate" for the indication, when the mortgage starts. Could we please have this new field before the field "MaturityDate"?

Type: see Date