### PR TITLE
New Field: Date Price Fixing

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2194,7 +2194,8 @@ components:
           $ref: '#/components/schemas/Date'
         offerDate:
           $ref: '#/components/schemas/Date'
-          description: 'The date when the offer is made by the FI.'
+          description: 'The date when the offer is made by the FI. Optional field for use cases where no MortageOffer object is used and therefore the offer date needs to be directly in Mortgage object. '
+          example: 2018-04-05
         validTo:
           $ref: '#/components/schemas/Date'
         interestRate:

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2192,6 +2192,9 @@ components:
           $ref: '#/components/schemas/Amount'
         validFrom:
           $ref: '#/components/schemas/Date'
+        offerDate:
+          $ref: '#/components/schemas/Date'
+          description: 'The date when the offer is made by the FI.'
         validTo:
           $ref: '#/components/schemas/Date'
         interestRate:
@@ -2394,9 +2397,6 @@ components:
           $ref: '#/components/schemas/AmountRange'
         increment:
           type: integer
-        datePriceFixing:
-          $ref: '#/components/schemas/Date'
-          description: 'The date when the price has been fixed'
     # ---------
 
     # ---- Party ----

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2394,6 +2394,9 @@ components:
           $ref: '#/components/schemas/AmountRange'
         increment:
           type: integer
+        datePriceFixing:
+          $ref: '#/components/schemas/Date'
+          description: 'The date when the price has been fixed'
     # ---------
 
     # ---- Party ----


### PR DESCRIPTION
We need a field which transfer us the date, when the pricing for the offer has been done:

Name: "datePriceFixing" or "offerValidFrom"
description: "The date when the price has been fixed" OR "The date when the offer has been made" Type: see Date

Can we add this field after the object "interest"?

changes in same lines in #73 