### PR TITLE
New Fields: TPP Applicant IDs

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2408,6 +2408,11 @@ components:
           format: uuid
           description: ApplicantId for primary applicant of the applicant party. In case of multiple applicants this field is mandatory.
           example: 576f8de3-6b30-4882-a7af-da2132a456cf
+        tppPrimaryApplicantId:
+          type: string
+          pattern: '^[a-zA-Z0-9]{6,10}$'
+          description: 'ApplicantId for the applying party defined by TPP'
+          example: 'asd23f'
         personList:
           type: array
           items:
@@ -2549,6 +2554,11 @@ components:
           format: uuid
           description: UUID v4 of the applicant (to be defined by TPP)
           example: 576f8de3-6b30-4882-a7af-da2132a456cf
+        tppApplicantId:
+          type: string
+          pattern: '^[a-zA-Z0-9]{6,10}$'
+          description: 'ApplicantId defined by TPP'
+          example: 'asd23f'
         applicantType:
           type: string
           example: individual

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2408,10 +2408,9 @@ components:
           format: uuid
           description: ApplicantId for primary applicant of the applicant party. In case of multiple applicants this field is mandatory.
           example: 576f8de3-6b30-4882-a7af-da2132a456cf
-        tppPrimaryApplicantId:
+        fiPrimaryApplicantId:
           type: string
-          pattern: '^[a-zA-Z0-9]{6,10}$'
-          description: 'ApplicantId for the applying party defined by TPP'
+          description: 'ApplicantId for primary applicant of the applicant party defined by the financial institute, only applicable in case of multiple applicants and if known at the moment of the application.'
           example: 'asd23f'
         personList:
           type: array
@@ -2554,10 +2553,9 @@ components:
           format: uuid
           description: UUID v4 of the applicant (to be defined by TPP)
           example: 576f8de3-6b30-4882-a7af-da2132a456cf
-        tppApplicantId:
+        fiApplicantId:
           type: string
-          pattern: '^[a-zA-Z0-9]{6,10}$'
-          description: 'ApplicantId defined by TPP'
+          description: 'ApplicantId of the applicant party defined by the financial institute, only applicable if known at the moment of the application.'
           example: 'asd23f'
         applicantType:
           type: string


### PR DESCRIPTION
In our communication between TPP and FI, we use the TPP Applicant ID to refer to the client and we connect the dots of the different application using this key.

Therefore we would like to add to following new field in the Object "Party": Name: tppPrimaryApplicantID
Description: ApplicantId for the applying party defined by TPP Type: string, pattern: '^[a-zA-Z0-9]{6,10}$'

For the same reason, we need a new field in the Object "Applicant":
Name: tppApplicantID
Description: ApplicantId defined by TPP
Type: string, pattern: '^[a-zA-Z0-9]{6,10}$'