### PR TITLE
New Field: Channel Type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2444,6 +2444,11 @@ components:
           enum:
             - buy
             - replacement
+         channelType:
+           type: string
+           enum: [advisor, direct]
+           description: 'The type of the channel the application was generated' 
+           example: 'advisor'
         replacementType:
           type: string
           description: 'NOT required when mortgage type is BUY, Values: entire, partial.'


### PR DESCRIPTION
In our software we know two different channels, on which an application can be entered. The channel might have an influence on the price or on which client advisor is relevant for this application.

For this reason, we would like to have a new field in the object "application": Name: channelType
Description: The type of the channel the application was generated string
enum: [advisor, direct]

"advisor" could also be replaced by "broker"