### PR TITLE
New Enum in Mortgage Type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2439,7 +2439,7 @@ components:
           $ref: '#/components/schemas/PropertyObject'
         mortgageType:
           type: string
-          description: 'Type of business, Values: buy, replacement.'
+          description: 'Type of business.'
           example: buy
           enum:
             - buy

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2444,6 +2444,7 @@ components:
           enum:
             - buy
             - replacement
+            - construction_financing
         replacementType:
           type: string
           description: 'NOT required when mortgage type is BUY, Values: entire, partial.'


### PR DESCRIPTION
In addition to the enum "buy" and "replacement" we consider "Baufinanzierung" as well as a mortgage type.

In "mortgageType", we would like to extend the enum by "construction_financing".