### PR TITLE
New Field: Name TPP

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2464,6 +2464,11 @@ components:
               maxLength: 70
               description: Surname of the TPP advisor
               example: Max
+            nameTpp:
+              type: string
+              maxLength: 70
+              description: 'Firm of the TPP advisor'
+              example: 'Muster Finanz AG'
             email:
               type: string
               description: Email of the TPP advisor


### PR DESCRIPTION
In our service, different Third Party Provider can apply for a mortgage. This is why we want to extend the object "tppAdvisorDetail" with a new field:

Name: nameTpp
Description: Firm of the TPP
Type: string, max 70