### PR TITLE
New Enum in Marital Status

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2582,6 +2582,8 @@ components:
                 - divorced
                 - widowed
                 - registered-partnership
+                - legally separated
+                - Partnership dissolved
             matrimonialPropertyScheme:
               type: string
               example: separateEstate


### PR DESCRIPTION
We have two more options of "marital status":

legally separated - gerichtlich getrennt
Partnership dissolved - aufgelöste Partnerschaft
Could we add these to the enum?