### PR TITLE
New Enum in Asset Type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2692,6 +2692,7 @@ components:
         - vested_benefit
         - life_insurance_3a
         - life_insurance_3b
+        - unpledged_building_plot
     AssetUsageType:
       description: Common set of asset usage types.
       type: string


### PR DESCRIPTION
An applicant of a mortgage can bring unpledged building plot as part of his assets (Eigenmittel). This enum is missing in the assetType.

Please add the enum: unpledged_building_plot