### PR TITLE
New Setup: Amount for Asset Type Insurances

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2711,7 +2711,7 @@ components:
         amount:
           $ref: '#/components/schemas/Amount'
           description: 'The amount of the asset e.g. market value of fungible investment, existing retirement asset in pension fund, surrender value in life insurance'
-        insurance sum:
+        insuranceSum:
           $ref: '#/components/schemas/Amount'
           description: 'The amount of the sum insured in life insurance'
         remark:

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2710,6 +2710,10 @@ components:
           $ref: '#/components/schemas/AssetType'
         amount:
           $ref: '#/components/schemas/Amount'
+          description: 'The amount of the asset e.g. market value of fungible investment, existing retirement asset in pension fund, surrender value in life insurance'
+        insurance sum:
+          $ref: '#/components/schemas/Amount'
+          description: 'The amount of the sum insured in life insurance'
         remark:
           type: string
         assetProvider:


### PR DESCRIPTION
For insurances (Asset Typ enum: life_insurance_3a, life_insurance_3b) two different types of amount are interesting for the FI:

surrender value / Rückkaufswert
insurance sum / Versicherungssumme
Both of them will be entered in the core banking system. So we would like to transfer both amounts. Is it possible to add a new field in the object "Asset": name: insurance sum
description: The amount of the sum insured
Type: see Amount

So, we can send the surrender value in the current field "amount" and send the insurance sum in the new field.