### PR TITLE
New Enum in Income Types

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2759,6 +2759,11 @@ components:
         - asset_consumption_after_retirement
         - fixed_expenses
         - dividend
+        - leasing_payment
+        - consumer_loan_payment
+        - child_allowance_payment
+        - rental_costs
+        - costs_for_additional_properties
     DocumentType:
       description: All supported document types.
         For the enum value tax_statement. Tax statement is required.


### PR DESCRIPTION
Some options are missing in the enum of the "income Types": leasing_payment, consumer_loan_payment, child_allowance_payment, rental_costs, costs_for_additional_properties

Please add these to the enum.