### PR TITLE
Grammar mistake in Other Features in V3.0

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2120,7 +2120,7 @@ components:
               type: array
               items:
                 type: string
-                enum: [coowned_garden_terrace_room, coowned_indoor_pool, coowned_outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, elevator_in_stairwell, elevator_into_apartment, ventilation_system_without_mingergie, barrier-free_living, automated_building_control, ventilation_system_without_minergie]
+                enum: [coowned_garden_terrace_room, coowned_indoor_pool, coowned_outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, elevator_in_stairwell, elevator_into_apartment, barrier-free_living, automated_building_control, ventilation_system_without_minergie]
                 description: 'Additional features and services.'
                 example: 'coowned_outdoor_pool'
             quote:
@@ -2176,7 +2176,7 @@ components:
               type: array
               items:
                 type: string
-                enum: [ventilation_system_without_mingergie, barrier-free_living, automated_building_control, ventilation_system_without_minergie, indoor_pool, outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, passenger_elevator, freight_elevator]
+                enum: [barrier-free_living, automated_building_control, ventilation_system_without_minergie, indoor_pool, outdoor_pool, whirlpool_sauna, heated_conservatory, unheated_conservatory, security_system, chimney, passenger_elevator, freight_elevator]
                 description: 'Additional features and services.'
                 example: 'outdoor_pool'
             houseType:


### PR DESCRIPTION
In the field "otherFeatures" in the object "propertyBuildingInformation" and in the object "propertyFlatInformation", there is a grammar mistake in the enum ventilation_system_without_mingergie.
Could we correct that at both places?

I have added the new enum: ventilation_system_without_minergie -> for next release
we should delete enum: ventilation_system_without_mingergie in release V3.0
So --> deleted "..mingergie.." at two places