### PR TITLE
Renaming Estimation Amount in Release V3.0

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2233,7 +2233,7 @@ components:
               enum:
                 - iazi
                 - wup
-            amount:
+            marketValue:
               $ref: '#/components/schemas/Amount'
               description: 'Estimated Market value of the property'
             statisticalPriceRangeMax:


### PR DESCRIPTION
In the object "Estimation" you have the following fields:

estimationSourceType
amount
estimationDate
Estimation tools like WuP and IAZI know several "amounts". Therefore the field "Amount" is not meaningful. I suggest to rather call this field "marketValue".

Step 1 in next Release: description added : "Estimated Market value of the property" Step 2 in Release V3.0: renaming of amount to "marketValue"

So --> renaming of "amount" to "marketValue"