### PR TITLE
New Setup: Volume in propertyBuildingInformation

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2163,6 +2163,14 @@ components:
               type: integer
               description: 'The volume of the house including the garage.'
               example: 1500
+            volumeIncludingGarageInhouse:
+              type: integer
+              description: 'The volume of the house including the inhouse garage (relevant for WuP).'
+              example: 1500
+              volumeIncludingAllGarages:
+              type: integer
+              description: 'The volume of the house including all inhouse and external garages and garage boxes (relevant for IAZI).'
+              example: 1620
             landArea:
               type: integer
               description: 'The surface area of the land.'

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2167,7 +2167,7 @@ components:
               type: integer
               description: 'The volume of the house including the inhouse garage (relevant for WuP).'
               example: 1500
-              volumeIncludingAllGarages:
+            volumeIncludingAllGarages:
               type: integer
               description: 'The volume of the house including all inhouse and external garages and garage boxes (relevant for IAZI).'
               example: 1620


### PR DESCRIPTION
IAZI and WüestDimensions use different estimation approaches in respect of volume in connection with garages.

both: volume of internal garages is automatically taken into account in the volume -> no issue IAZI: volume of external garages and garage boxes need to be added on the normal volume (standard volume: 60m3 each) WuP: amount of external garages and garage boxes are transfered as own fields and should not be transfered in the normal volume Therefore, we need to have two different fields for volume:

name: volumeIncludingGarageInhouse (change in naming of the current field «volumeIncludingGarage», relevant for WuP) description: The volume of the house including the inhouse garage (relevant for WuP). type: integer
example 1500
volumeIncludingAllGarages (new field, relevant for IAZI) description: The volume of the house including all inhouse and external garages and garage boxes (relevant for IAZI). type: integer
example 1620
I would suggest normal meccano for change:
add two new fields in next release and remove old field "volumeIncludingGarage" in release V3.0

So --> added two new fields