### PR TITLE
Required Fields in Liabilities and Income

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2821,6 +2821,9 @@ components:
               type: array
               items:
                 type: object
+                required:
+                  - incomeType
+                  - amount
                 properties:
                   incomeType:
                     $ref: '#/components/schemas/IncomeType'
@@ -2832,6 +2835,9 @@ components:
               type: array
               items:
                 type: object
+                required:
+                  - liabilityType
+                  - amount
                 properties:
                   liabilityType:
                     type: string

--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2831,6 +2831,10 @@ components:
                     $ref: '#/components/schemas/Amount'
                   remark:
                     type: string
+                  incomeProvider:
+                    description: 'Income provider for each income or cost position can be transfered.'
+                    type: string
+                    example: 'Employer AG'
             liabilities:
               type: array
               items:
@@ -2841,7 +2845,7 @@ components:
                 properties:
                   liabilityType:
                     type: string
-                    example: mortgage
+                    example: 'mortgage'
                     description: Liability type
                     enum:
                       - leasing
@@ -2852,6 +2856,10 @@ components:
                     $ref: '#/components/schemas/Amount'
                   remark:
                     type: string
+                  liabilityProvider:
+                    description: 'Name of the liability provider or creditor.'
+                    type: string
+                    example: 'Leasing Firm AG'
             assets:
               type: array
               items:


### PR DESCRIPTION
In "Asset" the fields "assetType" and "amount" are required. in "liabilites" and "income", these two fields are not required. How come? We should mark these two fields in "liabilities" and "income" as required, too.

There is one more difference: asset has an additional field "assetProvider". Do we need/want this field for "liability" and "income" as well?

Anyway, why is there a different specification format for "liabilities" and "income" than for "asset"? "asset" is separately specified under "mortgage date types" whereas the other two are specified in the normal structure. Do we want to change it?


-> In this Pull request, only 1st point is addressed.