### PR TITLE
Change details for commonErrorResponse

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -1859,9 +1859,10 @@ components:
           example:
             This is the general problem description
         detail:
-          type: string
-          example:
-            Detailed problem description with respect to the current request
+          type: array
+          items:
+            type: string
+            example: List of detailed problem description with respect to the current request
         instance:
           type: string
           example:


### PR DESCRIPTION
Change details for commonErrorResponse from string to array [string].

At the moment for every error response only ONE string with details can be returned. As originally suggested by lars and oleg, we change the type to array [string].
Scope: rls3