### PR TITLE
New Enum in Asset Type

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2912,9 +2912,13 @@ components:
         - reservation_deposit
         - advancement_of_inheritance
         - third_pillar
+        - third_pillar_3a
+        - third_pillar_3b
         - pension_fund
         - third_party_loan
         - third_pillar_fund
+        - third_pillar_fund_3b
+        - third_pillar_fund_3a
         - fungible_investments
         - other
         - vested_benefit


### PR DESCRIPTION
Due to the current enum in Asset Type we can not transfer the information if the asset in third_pillar_fund and third_pillar is in 3a or 3b.

Therefore we want to add new enums:

third_pillar_3a
third_pillar_3b
third_pillar_fund_3a
third_pillar_fund_3b