### PR TITLE
Fix Rls 3.0.0

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2223,10 +2223,6 @@ components:
               type: boolean
               description: 'If the roof floor is expandable true, else false.'
               example: false
-            volumeIncludingGarage:
-              type: integer
-              description: 'The volume of the house including the garage.'
-              example: 1500
             volumeIncludingGarageInhouse:
               type: integer
               description: 'The volume of the house including the inhouse garage (relevant for WuP).'
@@ -2299,6 +2295,10 @@ components:
         estimation:
           type: object
           properties:
+            estimationId:
+              type: string
+              description: 'ID of the property estimation to connect the done estimation in the core banking system with the estimation of the tpp in the external estimation tool.'
+              example: 'asd23f'
             estimationSourceType:
               type: string
               example: iazi
@@ -2325,10 +2325,6 @@ components:
         publicNotarization:
           $ref: '#/components/schemas/Date'
           description: 'Date of public notarization'
-        estimationId:
-          type: string
-          description: 'ID of the property estimation to connect the done estimation in the core banking system with the estimation of the tpp in the external estimation tool.'
-          example: 'asd23f'
         remarks:
           type: string
     # ---------


### PR DESCRIPTION
- Fixed: estimationId should be part of the estimation object
- Fixed: volumeIncludingGarage should have been deleted in Rls 3.0.0 (PR#103)