### PR TITLE
InsuranceSum in UsedAssets

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -3167,6 +3167,9 @@ components:
           $ref: '#/components/schemas/AssetType'
         amount:
           $ref: '#/components/schemas/Amount'
+        insuranceSum:
+          $ref: '#/components/schemas/Amount'
+          description: 'The amount of the sum insured in life insurance'
         usageType:
           $ref: '#/components/schemas/AssetUsageType'
         applicantId:


### PR DESCRIPTION
We introduced a new data field in the object "Asset": insuranceSum. We want to add this data field in the object "UsedAsset" as optional.

insuranceSum:
$ref: '#/components/schemas/Amount'
description: 'The amount of the sum insured in life insurance'