### PR TITLE
Replacement including credit increase

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2881,6 +2881,12 @@ components:
           example: 6e61ff5d-3ffd-4254-a77d-73cc25d35e92
         amount:
           $ref: '#/components/schemas/Amount'
+        increaseAmount:
+          $ref: '#/components/schemas/Amount'
+        increasePurpose:
+          type: string
+          description: The purpose of the increase.
+          example: renovation of the kitchen
         amortizations:
           $ref: '#/components/schemas/Amortizations'
         tranches:
@@ -2963,6 +2969,12 @@ components:
           description: Uuid v4 of the corresponding application
         amount:
           $ref: '#/components/schemas/Amount'
+        increaseAmount:
+          $ref: '#/components/schemas/Amount'
+        increasePurpose:
+          type: string
+          description: The purpose of the increase.
+          example: renovation of the kitchen
         tranches:
           type: array
           items:


### PR DESCRIPTION
How do you handle/transfer data in the mortgage type replacement when the credit limit should be increased?

We would like to transfer:

amount of increase
purpose of increase
withdrawn pension fund in past (question of handling in any case, also without credit increase) We would recommend to add new fields:

amount of increase in our TKB-Object "Financing" after the field "amount" and in the use case "financingRequest" after the field "amount" -> "increaseAmount" purpose of increase just after "increaseAmount" in both objects ->"increasePurpose" transfer the amount of withdrawn pension fund in past in the UsedAssets with normal meccano (because UsedAssets is not used in the mortgagetype "Replacement", right?)