### PR TITLE
New Enum in Matrimonial Property Scheme - Rel 3.x

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -3057,6 +3057,7 @@ components:
                 - jointEstate
                 - separateEstate
                 - contributionToJointlyAcquiredProperty
+                - none
             jobSituation:
               type: string
               example: employed


### PR DESCRIPTION
For each applicant, in the field "matrimonialPropertyScheme" in the object "applicantDetail", we can send information how the property is owned: jointEstate
separateEstate
contributionToJointAcquiredProperty

In Case, the mortgage is for two debtor, but the property is owned by only Debtor A of these two debtor: What do you send in this field for Debtor A? --> I would say "separateEstate" What do you send in this field for Debtor B? --> There is no enum for this. Do you send it empty?

I would suggest to add a new enum: "none" or "n-a". So that we can send a clear message to the FI.