### PR TITLE
New Enum in Matrimonial Property Scheme - Rel 4.0 final solution

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2083,6 +2083,13 @@ components:
             - other  
           description: The class of property (Main residence, second residence, rented).
           example: main_residence
+        matrimonialPropertyScheme:
+          type: string
+          example: separateEstate
+          enum:
+            - jointEstate
+            - separateEstate
+            - contributionToJointlyAcquiredProperty
         floorPlan:
           type: string
           enum: 
@@ -3050,13 +3057,13 @@ components:
                 - registered-partnership
                 - legally-separated
                 - partnership-dissolved
-            matrimonialPropertyScheme:
+            PropertyOwner:
               type: string
-              example: separateEstate
+              example: 'yes'
               enum:
-                - jointEstate
-                - separateEstate
-                - contributionToJointlyAcquiredProperty
+                - yes
+                - no
+              description: Is the applicant owner of the financed property? Yes/No
             jobSituation:
               type: string
               example: employed


### PR DESCRIPTION
For each applicant, in the field "matrimonialPropertyScheme" in the object "applicantDetail", we can send information how the property is owned: jointEstate
separateEstate
contributionToJointAcquiredProperty

In Case, the mortgage is for two debtor, but the property is owned by only Debtor A of these two debtor: What do you send in this field for Debtor A? --> I would say "separateEstate" What do you send in this field for Debtor B? --> There is no enum for this. Do you send it empty?

I would suggest to add a new enum: "none" or "n-a". So that we can send a clear message to the FI.