### PR TITLE
Linking additional properties to the respective mortgage

### DIFF
--- a/mortgageAPI.yaml
+++ b/mortgageAPI.yaml
@@ -2907,6 +2907,8 @@ components:
                   valueAdditionalProperty:
                     $ref: '#/components/schemas/Amount'
                     description: Value of the additional property
+                  mortgageAmountAdditionalProperty:
+                    $ref: '#/components/schemas/Amount'
                   propertyTypeAdditionalProperty:
                     type: string
                     enum:


### PR DESCRIPTION
It concerns additional properties and the respective mortgages with a third party. Currently, it is not possible to identify which mortgage is linked to which additional property, as they are stored under different levels. The respective mortgage is stored under ApplicantDetail - financialSituation - liabilities and the additional property is stored under ApplicantDetail - financialSituation - additionalProperties This is especially a problem if there ismore than one additional property. We suggest keeping the existing mortgage under liabilities and add an additional field under additionalProperties such as i.e. mortgageAmountAdditionalProperty