### PR TITLE
Fix definitions of PropertyType and UsageType by swapping these two

### DIFF
--- a/src/components/schemas/PropertyType.yaml
+++ b/src/components/schemas/PropertyType.yaml
@@ -1,6 +1,18 @@
-description: 'The type of usage of the property: self, let.'
+description: 'The type of property.'
 type: string
 enum:
-  - self
-  - let
-example: self
+  - single_family_house
+  - condominium
+  - vacation_house
+  - vacation_condominium
+  - agricultural_farm
+  - 2or3_family_house
+  - multi_family_house
+  - residential_building_plot
+  - building_plot_other
+  - mixed_property
+  - commercial_condominium
+  - office_building
+  - industrial_building
+  - special_object
+example: single_family_house

--- a/src/components/schemas/UsageType.yaml
+++ b/src/components/schemas/UsageType.yaml
@@ -1,18 +1,6 @@
-description: 'The type of property.'
+description: 'The type of usage of the property: self, let.'
 type: string
 enum:
-  - single_family_house
-  - condominium
-  - vacation_house
-  - vacation_condominium
-  - agricultural_farm
-  - 2or3_family_house
-  - multi_family_house
-  - residential_building_plot
-  - building_plot_other
-  - mixed_property
-  - commercial_condominium
-  - office_building
-  - industrial_building
-  - special_object
-example: single_family_house
+  - self
+  - let
+example: self


### PR DESCRIPTION
In recent PR #196, `UsageType` and `PropertyType` were extracted into separate definition files.
Unfortunately, the schema definitions were accidentally swapped.

This PR corrects the error by swapping the contents of `PropertyType.yaml` and `UsageType.yaml`.